### PR TITLE
Accommodate breaking changes to libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysconf"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Gary M. Josack <gary@byoteki.com>"]
 repository = "https://github.com/gmjosack/sysconf.rs"
 documentation = "http://gmjosack.github.io/sysconf.rs"
@@ -8,5 +8,5 @@ license = "Apache-2.0"
 description = "Small safe wrapper around sysconf"
 
 [dependencies]
-libc = "*"
+libc = "0.2.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 extern crate libc;
 
-use libc::funcs::posix88::unistd;
-use libc::types::os::arch::c95::c_int;
 use std::result;
-
+use self::libc::c_int;
 
 pub type Result<T> = result::Result<T, SysconfError>;
 
@@ -73,8 +71,8 @@ pub enum SysconfVariable {
 }
 
 pub fn sysconf(name: SysconfVariable) -> Result<i64> {
-    match unsafe { unistd::sysconf(name as c_int) } {
-        -1   => Err(SysconfError::Invalid),
-        ret  => Ok(ret),
+    match unsafe { libc::sysconf(name as c_int) } {
+        -1  => Err(SysconfError::Invalid),
+        ret => Ok(ret),
     }
 }


### PR DESCRIPTION
This fixes the import paths for some types used from libc. This also
removes the wildcard dependency on libc, which is no longer allowed for
published crates.